### PR TITLE
bump sdk version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
 [[package]]
 name = "oasis-runtime-sdk"
 version = "0.1.0"
-source = "git+https://github.com/oasisprotocol/oasis-sdk?branch=main#05f02ca546ae7b211fd7c7f7951a4a7f43e33fb2"
+source = "git+https://github.com/oasisprotocol/oasis-sdk?branch=main#77cb48e14aa70eba9178aa37a79becfcc18b1710"
 dependencies = [
  "anyhow",
  "base64",

--- a/client-sdk/ts-web/playground/consts.sh
+++ b/client-sdk/ts-web/playground/consts.sh
@@ -1,5 +1,5 @@
-BUILD_NUMBER=3935
-OASIS_NODE_ARTIFACT=https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/3935/jobs/f3463f8c-2d2c-4381-a115-5d1f34b9ff44/artifacts/b4fa89d0-2712-4591-a5d5-e70efea9db3a
-OASIS_NET_RUNNER_ARTIFACT=https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/3935/jobs/f3463f8c-2d2c-4381-a115-5d1f34b9ff44/artifacts/bdfa13dc-d111-4860-9823-a53cea0cb218
-OASIS_CORE_RUNTIME_LOADER_ARTIFACT=https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/3935/jobs/0de25057-fa8c-46be-8fe1-bec554e6bdf3/artifacts/466a2eaa-79be-41a0-9430-0e81c86bc3dd
-SIMPLE_KEYMANAGER_ARTIFACT=https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/3935/jobs/9fb4239c-3421-41a1-b44e-3dd7303b6755/artifacts/8d1b5c41-d0bc-481c-a1e8-116eb7aed574
+BUILD_NUMBER=4079
+OASIS_NODE_ARTIFACT=https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/4079/jobs/5af38a50-1f03-4b8a-a715-6fa3ef132704/artifacts/13c93842-c42b-488d-b8f3-afec6d69508c
+OASIS_NET_RUNNER_ARTIFACT=https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/4079/jobs/5af38a50-1f03-4b8a-a715-6fa3ef132704/artifacts/072c15dd-1851-46f0-93f1-e98d46325dc2
+OASIS_CORE_RUNTIME_LOADER_ARTIFACT=https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/4079/jobs/d0e17695-ed93-4f94-988a-ca538e0a817a/artifacts/71b4fc0a-04e3-430f-b74d-e30d847c7a2c
+SIMPLE_KEYMANAGER_ARTIFACT=https://buildkite.com/organizations/oasisprotocol/pipelines/oasis-core-ci/builds/4079/jobs/19e93dde-a442-4280-8e3f-414dcc031aec/artifacts/ad7871bd-9725-4dbd-a02b-80107dbf1ee5

--- a/examples/user-witness-flow/go.mod
+++ b/examples/user-witness-flow/go.mod
@@ -3,7 +3,7 @@ module github.com/oasisprotocol/oasis-bridge/examples/user-witness-flow
 go 1.15
 
 require (
-	github.com/oasisprotocol/oasis-core/go v0.2011.1-0.20210219132338-9998deaee02f
-	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-20210219140407-d7f86e6eada7
-	google.golang.org/grpc v1.35.0
+	github.com/oasisprotocol/oasis-core/go v0.2011.1-0.20210302134859-d186644faee8
+	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-20210318213753-77cb48e14aa7
+	google.golang.org/grpc v1.36.0
 )

--- a/examples/user-witness-flow/go.sum
+++ b/examples/user-witness-flow/go.sum
@@ -433,7 +433,7 @@ github.com/libp2p/go-libp2p-core v0.5.7/go.mod h1:txwbVEhHEXikXn9gfC7/UDDw7rkxuX
 github.com/libp2p/go-libp2p-core v0.6.0/go.mod h1:txwbVEhHEXikXn9gfC7/UDDw7rkxuX0bJvM49Ykaswo=
 github.com/libp2p/go-libp2p-core v0.7.0/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
 github.com/libp2p/go-libp2p-core v0.8.0/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
-github.com/libp2p/go-libp2p-core v0.8.4/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
+github.com/libp2p/go-libp2p-core v0.8.5/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.2.0/go.mod h1:s4VGaxYMbw4+4+tsoQTqh7wfxg97AEdo4GYBt6BadWg=
 github.com/libp2p/go-libp2p-discovery v0.3.0/go.mod h1:o03drFnz9BVAZdzC/QUQ+NeQOu38Fu7LJGEOK2gQltw=
@@ -642,10 +642,10 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/oasisprotocol/deoxysii v0.0.0-20200527154044-851aec403956/go.mod h1:cE5EgXTIhq5oAVdZ7LZd1FjTRLALPEzv93CWzBtDkyI=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea h1:r4MhxgqQ1bed0fQhRINBM50Rbwsgma6oEjG4zQ444Lw=
 github.com/oasisprotocol/ed25519 v0.0.0-20210127160119-f7017427c1ea/go.mod h1:IZbb50w3AB72BVobEF6qG93NNSrTw/V2QlboxqSu3Xw=
-github.com/oasisprotocol/oasis-core/go v0.2011.1-0.20210219132338-9998deaee02f h1:JVH5RUImUYhk3TIwWvN3816nycpAqyBFEKualYfzqus=
-github.com/oasisprotocol/oasis-core/go v0.2011.1-0.20210219132338-9998deaee02f/go.mod h1:pRPwomJe2dhI9bl41k+2afO5Waejw6K3KLnYvYf7+lw=
-github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-20210219140407-d7f86e6eada7 h1:wbdoyFW66fF7NgZMJMWdVh5+oxxFd8W+r2X6W/p5CHI=
-github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-20210219140407-d7f86e6eada7/go.mod h1:UNY36+ukbwVEC020Es8mQy2/x9qpXV9H5RYIBYBm4ng=
+github.com/oasisprotocol/oasis-core/go v0.2011.1-0.20210302134859-d186644faee8 h1:nqguGM4YZJojeUoWTPQTCJ/zkkMU6q6yxqoZWlrVI1U=
+github.com/oasisprotocol/oasis-core/go v0.2011.1-0.20210302134859-d186644faee8/go.mod h1:ObHSwk0UJ/HxGQmfsqN3Pn45ji/9AVkFrfi1Vbb34rQ=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-20210318213753-77cb48e14aa7 h1:t8f7k0KwIiFyhiRIQPul+lr14k62IafEIrGKZsj9PVg=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.0.0-20210318213753-77cb48e14aa7/go.mod h1:fbRy7GK/pgiWalNOWI5fJskKj/ORCaJrZPIrysBixiU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -716,8 +716,8 @@ github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB8
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.16.0 h1:VMiIg2fcMM+QkvAaPo6Hatk8OgpVHh4Yzp1+ljjjQAQ=
-github.com/prometheus/common v0.16.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.17.0 h1:kDIZLI74SS+3tedSvEkykgBkD7txMxaJAPj8DtJUKYA=
+github.com/prometheus/common v0.17.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -1119,6 +1119,8 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.35.0 h1:TwIQcH3es+MojMVojxxfQ3l3OF2KzlRxML2xZq0kRo8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
+google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc/examples v0.0.0-20200731180010-8bec2f5d898f h1:HNNmM2dnxUknBEJDvuCRZcUzhGbhkz00ckV2ha2gFJY=
 google.golang.org/grpc/examples v0.0.0-20200731180010-8bec2f5d898f/go.mod h1:TGiSRL2BBv2WqzfsFNWYp/pkWdtf5kbZS/DQ9Ee3mWk=
 google.golang.org/grpc/security/advancedtls v0.0.0-20200902210233-8630cac324bf h1:IqdIxEnvZreeZMpDPbAA66R/PkRH6AD255RbxyuyfEY=


### PR DESCRIPTION
up to https://github.com/oasisprotocol/oasis-sdk/pull/19

todo:
- [x] update rust dependency to master after https://github.com/oasisprotocol/oasis-sdk/pull/19 merges
- [x] update go dependency to master after https://github.com/oasisprotocol/oasis-sdk/pull/19 merges

on top of #17 