### PR TITLE
ci: rename e2e to e2e-go

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -106,9 +106,9 @@ jobs:
         working-directory: client-sdk/ts-web
         run: npx -c 'cypress run'
 
-  e2e:
+  e2e-go:
     # NOTE: This name appears in GitHub's Checks API.
-    name: e2e
+    name: e2e-go
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
from https://github.com/oasisprotocol/oasis-bridge/pull/36#discussion_r606118148

> Maybe call it `e2e-go` to be consistent with the above e2e test for ts-web.


